### PR TITLE
Drop unused git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/apk-builder"]
-	path = deps/apk-builder
-	url = https://github.com/rust-windowing/android-rs-glue


### PR DESCRIPTION
deps/apk-builder isn't used in tree and can be removed.
Fixes https://github.com/lapce/lapce/issues/509

Compile-tested on Linux x86.