### PR TITLE
wayland: zwlr_layer_shell_v1 support (Layer / Anchor / KeyboardInteractivity)

### DIFF
--- a/winit-wayland/src/layer_shell.rs
+++ b/winit-wayland/src/layer_shell.rs
@@ -1,0 +1,103 @@
+//! Public types for `zwlr_layer_surface_v1` support.
+//!
+//! Build a window with [`LayerShellAttributes`] via
+//! [`WindowAttributesWayland::with_layer_shell`] to create a layer surface
+//! instead of an `xdg_toplevel`. The compositor must advertise
+//! `wlr-layer-shell-unstable-v1`; on compositors that don't (notably GNOME
+//! Mutter), [`crate::Window::new`] returns an error and the caller is expected
+//! to fall back to a regular toplevel.
+
+use bitflags::bitflags;
+
+use winit_core::monitor::MonitorHandle;
+
+/// Z-layer for a `zwlr_layer_surface_v1`.
+///
+/// Matches the four values defined by the `wlr-layer-shell-unstable-v1`
+/// protocol. `Top` and `Overlay` paint above normal toplevels; `Bottom`
+/// and `Background` paint below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum Layer {
+    Background,
+    Bottom,
+    #[default]
+    Top,
+    Overlay,
+}
+
+bitflags! {
+    /// Edges of the output a layer surface is anchored to.
+    ///
+    /// Setting both opposite anchors (`TOP | BOTTOM` or `LEFT | RIGHT`)
+    /// stretches the surface across that axis. Setting all four anchors
+    /// makes the surface fullscreen on the output.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+    pub struct Anchor: u32 {
+        const TOP    = 1;
+        const BOTTOM = 2;
+        const LEFT   = 4;
+        const RIGHT  = 8;
+    }
+}
+
+/// How a layer surface participates in keyboard focus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KeyboardInteractivity {
+    /// Surface receives no keyboard input.
+    None,
+    /// Surface receives keyboard input when focused by the compositor.
+    /// This is what rofi, wofi, and similar pickers use: the compositor
+    /// grants focus on click / per-anchor policy and lets compositor
+    /// bindings continue to fire alongside.
+    OnDemand,
+    /// Surface captures all keyboard input while visible. Used by
+    /// screen lockers and login prompts; the compositor sends key events
+    /// here even when the previously-focused toplevel would otherwise
+    /// have them.
+    Exclusive,
+}
+
+impl Default for KeyboardInteractivity {
+    fn default() -> Self {
+        // OnDemand by default — Exclusive behaves like a lockscreen and
+        // suppresses every compositor binding including window-close
+        // shortcuts. Callers like screen lockers can opt in explicitly.
+        KeyboardInteractivity::OnDemand
+    }
+}
+
+/// Attributes describing a `zwlr_layer_surface_v1`.
+///
+/// Build a window with these attributes via
+/// [`WindowAttributesWayland::with_layer_shell`] to create a layer surface
+/// instead of an `xdg_toplevel`.
+#[derive(Debug, Clone)]
+pub struct LayerShellAttributes {
+    pub layer: Layer,
+    pub anchor: Anchor,
+    /// Distance the surface reserves on its anchor edge. `-1` means
+    /// "ignore other exclusive zones on this output" (typical for
+    /// overlays like launchers). `0` requests no reservation.
+    pub exclusive_zone: i32,
+    /// `(top, right, bottom, left)` margins in surface-local pixels.
+    pub margin: (i32, i32, i32, i32),
+    pub keyboard_interactivity: KeyboardInteractivity,
+    /// Used by the compositor for debugging / IPC (e.g. `hyprctl layers`).
+    pub namespace: String,
+    /// Output to place the surface on. `None` lets the compositor pick.
+    pub output: Option<MonitorHandle>,
+}
+
+impl Default for LayerShellAttributes {
+    fn default() -> Self {
+        Self {
+            layer: Layer::default(),
+            anchor: Anchor::TOP | Anchor::LEFT | Anchor::RIGHT,
+            exclusive_zone: -1,
+            margin: (0, 0, 0, 0),
+            keyboard_interactivity: KeyboardInteractivity::default(),
+            namespace: String::from("winit"),
+            output: None,
+        }
+    }
+}

--- a/winit-wayland/src/layer_shell.rs
+++ b/winit-wayland/src/layer_shell.rs
@@ -41,7 +41,12 @@ bitflags! {
 }
 
 /// How a layer surface participates in keyboard focus.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// Defaults to [`OnDemand`][KeyboardInteractivity::OnDemand] — Exclusive
+/// behaves like a lockscreen and suppresses every compositor binding
+/// (including window-close shortcuts). Callers like screen lockers can opt
+/// in explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum KeyboardInteractivity {
     /// Surface receives no keyboard input.
     None,
@@ -49,21 +54,13 @@ pub enum KeyboardInteractivity {
     /// This is what rofi, wofi, and similar pickers use: the compositor
     /// grants focus on click / per-anchor policy and lets compositor
     /// bindings continue to fire alongside.
+    #[default]
     OnDemand,
     /// Surface captures all keyboard input while visible. Used by
     /// screen lockers and login prompts; the compositor sends key events
     /// here even when the previously-focused toplevel would otherwise
     /// have them.
     Exclusive,
-}
-
-impl Default for KeyboardInteractivity {
-    fn default() -> Self {
-        // OnDemand by default — Exclusive behaves like a lockscreen and
-        // suppresses every compositor binding including window-close
-        // shortcuts. Callers like screen lockers can opt in explicitly.
-        KeyboardInteractivity::OnDemand
-    }
 }
 
 /// Attributes describing a `zwlr_layer_surface_v1`.

--- a/winit-wayland/src/lib.rs
+++ b/winit-wayland/src/lib.rs
@@ -34,6 +34,7 @@ macro_rules! os_error {
 }
 
 mod event_loop;
+pub mod layer_shell;
 mod output;
 mod seat;
 mod state;
@@ -41,6 +42,7 @@ mod types;
 mod window;
 
 pub use self::event_loop::{ActiveEventLoop, EventLoop};
+pub use self::layer_shell::{Anchor, KeyboardInteractivity, Layer, LayerShellAttributes};
 pub use self::window::Window;
 
 /// Additional methods on [`ActiveEventLoop`] that are specific to Wayland.
@@ -100,6 +102,7 @@ pub(crate) struct ApplicationName {
 pub struct WindowAttributesWayland {
     pub(crate) name: Option<ApplicationName>,
     pub(crate) activation_token: Option<ActivationToken>,
+    pub(crate) layer_shell: Option<LayerShellAttributes>,
 }
 
 impl WindowAttributesWayland {
@@ -119,6 +122,21 @@ impl WindowAttributesWayland {
     #[inline]
     pub fn with_activation_token(mut self, token: ActivationToken) -> Self {
         self.activation_token = Some(token);
+        self
+    }
+
+    /// Build the window as a `zwlr_layer_surface_v1` instead of an
+    /// `xdg_toplevel`. Used for rofi-style overlays, panels, and lockers.
+    ///
+    /// The compositor must support the `wlr-layer-shell-unstable-v1`
+    /// protocol; on compositors that don't (notably GNOME Mutter),
+    /// [`crate::Window::new`] returns an error and the caller is expected to
+    /// fall back to a regular toplevel.
+    ///
+    /// On X11 and other platforms this attribute is silently ignored.
+    #[inline]
+    pub fn with_layer_shell(mut self, attrs: LayerShellAttributes) -> Self {
+        self.layer_shell = Some(attrs);
         self
     }
 }

--- a/winit-wayland/src/lib.rs
+++ b/winit-wayland/src/lib.rs
@@ -80,14 +80,25 @@ pub trait EventLoopBuilderExtWayland {
 ///
 /// [`Window`]: crate::window::Window
 pub trait WindowExtWayland {
-    /// Returns `xdg_toplevel` of the window or [`None`] if the window is X11 window.
+    /// Returns `xdg_toplevel` of the window or [`None`] if this is a layer
+    /// surface.
     fn xdg_toplevel(&self) -> Option<NonNull<c_void>>;
+
+    /// Returns the raw `zwlr_layer_surface_v1` pointer if this window is a
+    /// layer surface built with [`WindowAttributesWayland::with_layer_shell`],
+    /// or [`None`] if it is an xdg toplevel.
+    fn wl_layer_surface(&self) -> Option<NonNull<c_void>>;
 }
 
 impl WindowExtWayland for dyn CoreWindow + '_ {
     #[inline]
     fn xdg_toplevel(&self) -> Option<NonNull<c_void>> {
         self.cast_ref::<Window>()?.xdg_toplevel()
+    }
+
+    #[inline]
+    fn wl_layer_surface(&self) -> Option<NonNull<c_void>> {
+        self.cast_ref::<Window>()?.wl_layer_surface()
     }
 }
 

--- a/winit-wayland/src/seat/pointer/relative_pointer.rs
+++ b/winit-wayland/src/seat/pointer/relative_pointer.rs
@@ -12,8 +12,8 @@ use sctk::reexports::protocols::wp::relative_pointer::zv1::{
 
 use sctk::globals::GlobalData;
 
-use winit_core::event::DeviceEvent;
 use crate::state::WinitState;
+use winit_core::event::DeviceEvent;
 
 /// Wrapper around the relative pointer.
 #[derive(Debug)]

--- a/winit-wayland/src/state.rs
+++ b/winit-wayland/src/state.rs
@@ -468,21 +468,55 @@ impl LayerShellHandler for WinitState {
         &mut self,
         _conn: &sctk::reexports::client::Connection,
         _qh: &QueueHandle<Self>,
-        _layer: &LayerSurface,
+        layer: &LayerSurface,
     ) {
-        // Layer-surface routing lands in the next commit (Window::new
-        // layer-surface branch). Until then this is a no-op stub so the
-        // `delegate_layer!` macro above resolves.
+        let window_id = super::make_wid(layer.wl_surface());
+        Self::queue_close(&mut self.window_compositor_updates, window_id);
     }
 
     fn configure(
         &mut self,
         _conn: &sctk::reexports::client::Connection,
         _qh: &QueueHandle<Self>,
-        _layer: &LayerSurface,
-        _configure: LayerSurfaceConfigure,
+        layer: &LayerSurface,
+        configure: LayerSurfaceConfigure,
         _serial: u32,
     ) {
-        // See `closed` above — wired in the layer-surface branch commit.
+        let window_id = super::make_wid(layer.wl_surface());
+
+        let pos = if let Some(pos) = self
+            .window_compositor_updates
+            .iter()
+            .position(|update| update.window_id == window_id)
+        {
+            pos
+        } else {
+            self.window_compositor_updates.push(WindowCompositorUpdate::new(window_id));
+            self.window_compositor_updates.len() - 1
+        };
+
+        if let Some(window_state) = self.windows.get_mut().get_mut(&window_id) {
+            let mut ws = window_state.lock().unwrap();
+            ws.mark_layer_configured();
+
+            // Per zwlr_layer_surface_v1.configure: zero on EITHER axis means
+            // "client decides for that axis". Mix axis-by-axis with the
+            // current size instead of treating any zero as "keep both".
+            let (new_w, new_h) = configure.new_size;
+            let current = ws.surface_size();
+            let new_size = dpi::LogicalSize::new(
+                if new_w > 0 { new_w } else { current.width },
+                if new_h > 0 { new_h } else { current.height },
+            );
+
+            // Mutate WindowState size via the layer-safe helper (avoids the
+            // xdg-specific CSD frame and xdg_surface.set_window_geometry side
+            // effects that the regular `resize()` triggers).
+            if new_size != current {
+                ws.apply_layer_size(new_size);
+            }
+
+            self.window_compositor_updates[pos].resized = true;
+        }
     }
 }

--- a/winit-wayland/src/state.rs
+++ b/winit-wayland/src/state.rs
@@ -516,7 +516,19 @@ impl LayerShellHandler for WinitState {
                 ws.apply_layer_size(new_size);
             }
 
+            // Always signal resize so the event loop delivers SurfaceResized
+            // and triggers the initial redraw. The xdg path does the same via
+            // `configure()` returning true on the first call.
             self.window_compositor_updates[pos].resized = true;
         }
+
+        // Mirror the xdg configure path: mark a redraw requested so the
+        // client is woken up to commit after the configure.
+        if let Some(requests) = self.window_requests.get_mut().get(&window_id) {
+            requests.redraw_requested.store(true, Ordering::Relaxed);
+        }
+
+        // Manually mark that we've got an event, since configure may not generate a resize.
+        self.dispatched_events = true;
     }
 }

--- a/winit-wayland/src/state.rs
+++ b/winit-wayland/src/state.rs
@@ -14,9 +14,7 @@ use sctk::reexports::client::{Connection, Proxy, QueueHandle};
 use sctk::registry::{ProvidesRegistryState, RegistryState};
 use sctk::seat::pointer::ThemedPointer;
 use sctk::seat::SeatState;
-use sctk::shell::wlr_layer::{
-    LayerShell, LayerShellHandler, LayerSurface, LayerSurfaceConfigure,
-};
+use sctk::shell::wlr_layer::{LayerShell, LayerShellHandler, LayerSurface, LayerSurfaceConfigure};
 use sctk::shell::xdg::window::{Window, WindowConfigure, WindowHandler};
 use sctk::shell::xdg::XdgShell;
 use sctk::shell::WaylandSurface;
@@ -484,10 +482,8 @@ impl LayerShellHandler for WinitState {
     ) {
         let window_id = super::make_wid(layer.wl_surface());
 
-        let pos = if let Some(pos) = self
-            .window_compositor_updates
-            .iter()
-            .position(|update| update.window_id == window_id)
+        let pos = if let Some(pos) =
+            self.window_compositor_updates.iter().position(|update| update.window_id == window_id)
         {
             pos
         } else {

--- a/winit-wayland/src/state.rs
+++ b/winit-wayland/src/state.rs
@@ -14,6 +14,9 @@ use sctk::reexports::client::{Connection, Proxy, QueueHandle};
 use sctk::registry::{ProvidesRegistryState, RegistryState};
 use sctk::seat::pointer::ThemedPointer;
 use sctk::seat::SeatState;
+use sctk::shell::wlr_layer::{
+    LayerShell, LayerShellHandler, LayerSurface, LayerSurfaceConfigure,
+};
 use sctk::shell::xdg::window::{Window, WindowConfigure, WindowHandler};
 use sctk::shell::xdg::XdgShell;
 use sctk::shell::WaylandSurface;
@@ -60,6 +63,11 @@ pub struct WinitState {
 
     /// The XDG shell that is used for windows.
     pub xdg_shell: XdgShell,
+
+    /// The wlr-layer-shell global, if the compositor advertises it.
+    /// `None` on GNOME Mutter and any compositor that doesn't implement
+    /// `wlr-layer-shell-unstable-v1`; callers fall back to xdg toplevels.
+    pub layer_shell: Option<LayerShell>,
 
     /// The currently present windows.
     pub windows: RefCell<AHashMap<WindowId, Arc<Mutex<WindowState>>>>,
@@ -180,6 +188,7 @@ impl WinitState {
             shm,
 
             xdg_shell: XdgShell::bind(globals, queue_handle).map_err(|err| os_error!(err))?,
+            layer_shell: LayerShell::bind(globals, queue_handle).ok(),
             xdg_activation: XdgActivationState::bind(globals, queue_handle).ok(),
             xdg_toplevel_icon_manager: XdgToplevelIconManagerState::bind(globals, queue_handle)
                 .ok(),
@@ -452,3 +461,28 @@ sctk::delegate_registry!(WinitState);
 sctk::delegate_shm!(WinitState);
 sctk::delegate_xdg_shell!(WinitState);
 sctk::delegate_xdg_window!(WinitState);
+sctk::delegate_layer!(WinitState);
+
+impl LayerShellHandler for WinitState {
+    fn closed(
+        &mut self,
+        _conn: &sctk::reexports::client::Connection,
+        _qh: &QueueHandle<Self>,
+        _layer: &LayerSurface,
+    ) {
+        // Layer-surface routing lands in the next commit (Window::new
+        // layer-surface branch). Until then this is a no-op stub so the
+        // `delegate_layer!` macro above resolves.
+    }
+
+    fn configure(
+        &mut self,
+        _conn: &sctk::reexports::client::Connection,
+        _qh: &QueueHandle<Self>,
+        _layer: &LayerSurface,
+        _configure: LayerSurfaceConfigure,
+        _serial: u32,
+    ) {
+        // See `closed` above — wired in the layer-surface branch commit.
+    }
+}

--- a/winit-wayland/src/window/mod.rs
+++ b/winit-wayland/src/window/mod.rs
@@ -28,12 +28,14 @@ use winit_core::window::{
     WindowLevel,
 };
 
-use crate::layer_shell::{Anchor as WinitAnchor, KeyboardInteractivity as WinitKi, Layer as WinitLayer};
 use super::event_loop::sink::EventSink;
 use super::output::MonitorHandle;
 use super::state::WinitState;
 use super::types::xdg_activation::XdgActivationTokenData;
 use super::ActiveEventLoop;
+use crate::layer_shell::{
+    Anchor as WinitAnchor, KeyboardInteractivity as WinitKi, Layer as WinitLayer,
+};
 use crate::{output, WindowAttributesWayland};
 
 pub(crate) mod state;
@@ -119,9 +121,10 @@ impl Window {
             let sctk_ki = convert_keyboard_interactivity(layer_attrs.keyboard_interactivity);
 
             // Resolve the output, if the caller pinned one.
-            let output = layer_attrs.output.as_ref().and_then(|mh| {
-                mh.cast_ref::<output::MonitorHandle>().map(|handle| &handle.proxy)
-            });
+            let output = layer_attrs
+                .output
+                .as_ref()
+                .and_then(|mh| mh.cast_ref::<output::MonitorHandle>().map(|handle| &handle.proxy));
 
             let layer_surface = layer_shell.create_layer_surface(
                 &queue_handle,
@@ -141,10 +144,12 @@ impl Window {
             // Per zwlr_layer_surface_v1.set_size: a dimension may be 0 only
             // if it's anchored to both opposite edges on that axis.
             // Width is "free" iff LEFT|RIGHT both set; height iff TOP|BOTTOM both set.
-            let horiz_free = sctk_anchor
-                .contains(sctk::shell::wlr_layer::Anchor::LEFT | sctk::shell::wlr_layer::Anchor::RIGHT);
-            let vert_free = sctk_anchor
-                .contains(sctk::shell::wlr_layer::Anchor::TOP | sctk::shell::wlr_layer::Anchor::BOTTOM);
+            let horiz_free = sctk_anchor.contains(
+                sctk::shell::wlr_layer::Anchor::LEFT | sctk::shell::wlr_layer::Anchor::RIGHT,
+            );
+            let vert_free = sctk_anchor.contains(
+                sctk::shell::wlr_layer::Anchor::TOP | sctk::shell::wlr_layer::Anchor::BOTTOM,
+            );
             // Use the already-resolved `size` (which incorporates the default
             // 800×600 fallback) as the anchor-free axis dimension, so a caller
             // who didn't set surface_size still gets a sensible non-zero value.
@@ -190,8 +195,7 @@ impl Window {
             };
 
             // Activate the window when the token is passed.
-            if let (Some(xdg_activation), Some(token)) =
-                (xdg_activation.as_ref(), activation_token)
+            if let (Some(xdg_activation), Some(token)) = (xdg_activation.as_ref(), activation_token)
             {
                 xdg_activation.activate(token.into_raw(), &surface);
             }
@@ -295,6 +299,21 @@ impl Window {
         match &self.window {
             state::Shell::Xdg(w) => NonNull::new(w.xdg_toplevel().id().as_ptr().cast()),
             state::Shell::Layer(_) => None,
+        }
+    }
+
+    /// Returns the raw `zwlr_layer_surface_v1` pointer if this window is a
+    /// layer surface, or [`None`] if it is an xdg toplevel.
+    pub(crate) fn wl_layer_surface(&self) -> Option<NonNull<c_void>> {
+        match &self.window {
+            state::Shell::Layer(l) => {
+                use sctk::shell::wlr_layer::SurfaceKind;
+                match l.kind() {
+                    SurfaceKind::Wlr(s) => NonNull::new(s.id().as_ptr().cast()),
+                    _ => None,
+                }
+            },
+            state::Shell::Xdg(_) => None,
         }
     }
 }

--- a/winit-wayland/src/window/mod.rs
+++ b/winit-wayland/src/window/mod.rs
@@ -145,10 +145,10 @@ impl Window {
                 .contains(sctk::shell::wlr_layer::Anchor::LEFT | sctk::shell::wlr_layer::Anchor::RIGHT);
             let vert_free = sctk_anchor
                 .contains(sctk::shell::wlr_layer::Anchor::TOP | sctk::shell::wlr_layer::Anchor::BOTTOM);
-            let fallback = attributes
-                .surface_size
-                .map(|s| s.to_logical::<u32>(1.0))
-                .unwrap_or(LogicalSize::new(600, 400));
+            // Use the already-resolved `size` (which incorporates the default
+            // 800×600 fallback) as the anchor-free axis dimension, so a caller
+            // who didn't set surface_size still gets a sensible non-zero value.
+            let fallback = size.to_logical::<u32>(1.0);
             let init_w = if horiz_free { 0 } else { fallback.width.max(1) };
             let init_h = if vert_free { 0 } else { fallback.height.max(1) };
             layer_surface.set_size(init_w, init_h);

--- a/winit-wayland/src/window/mod.rs
+++ b/winit-wayland/src/window/mod.rs
@@ -11,7 +11,10 @@ use sctk::reexports::client::protocol::wl_display::WlDisplay;
 use sctk::reexports::client::protocol::wl_surface::WlSurface;
 use sctk::reexports::client::{Proxy, QueueHandle};
 use sctk::reexports::protocols::xdg::activation::v1::client::xdg_activation_v1::XdgActivationV1;
-use sctk::shell::xdg::window::{Window as SctkWindow, WindowDecorations};
+use sctk::shell::wlr_layer::{
+    Anchor as SctkAnchor, KeyboardInteractivity as SctkKi, Layer as SctkLayer,
+};
+use sctk::shell::xdg::window::WindowDecorations;
 use sctk::shell::WaylandSurface;
 use tracing::warn;
 use winit_core::cursor::Cursor;
@@ -25,6 +28,7 @@ use winit_core::window::{
     WindowLevel,
 };
 
+use crate::layer_shell::{Anchor as WinitAnchor, KeyboardInteractivity as WinitKi, Layer as WinitLayer};
 use super::event_loop::sink::EventSink;
 use super::output::MonitorHandle;
 use super::state::WinitState;
@@ -39,8 +43,8 @@ pub use state::WindowState;
 /// The Wayland window.
 #[derive(Debug)]
 pub struct Window {
-    /// Reference to the underlying SCTK window.
-    window: SctkWindow,
+    /// The underlying shell role for this window.
+    window: state::Shell,
 
     /// Window id.
     window_id: WindowId,
@@ -95,23 +99,121 @@ impl Window {
 
         let size: Size = attributes.surface_size.unwrap_or(LogicalSize::new(800., 600.).into());
 
-        // We prefer server side decorations, however to not have decorations we ask for client
-        // side decorations instead.
-        let default_decorations = if attributes.decorations {
-            WindowDecorations::RequestServer
+        let (app_name, activation_token, layer_shell_attrs) =
+            match attributes.platform.take().and_then(|p| p.cast::<WindowAttributesWayland>().ok())
+            {
+                Some(attrs) => (attrs.name, attrs.activation_token, attrs.layer_shell),
+                None => (None, None, None),
+            };
+
+        // Build the shell role: layer surface if requested, otherwise xdg toplevel.
+        let shell = if let Some(layer_attrs) = layer_shell_attrs {
+            // If the compositor does not advertise wlr-layer-shell, return an error so the
+            // caller can fall back to an xdg toplevel.
+            let layer_shell = state.layer_shell.as_ref().ok_or_else(|| {
+                os_error!("compositor does not support wlr-layer-shell; fall back to xdg toplevel")
+            })?;
+
+            let sctk_layer = convert_layer(layer_attrs.layer);
+            let sctk_anchor = convert_anchor(layer_attrs.anchor);
+            let sctk_ki = convert_keyboard_interactivity(layer_attrs.keyboard_interactivity);
+
+            // Resolve the output, if the caller pinned one.
+            let output = layer_attrs.output.as_ref().and_then(|mh| {
+                mh.cast_ref::<output::MonitorHandle>().map(|handle| &handle.proxy)
+            });
+
+            let layer_surface = layer_shell.create_layer_surface(
+                &queue_handle,
+                surface.clone(),
+                sctk_layer,
+                Some(layer_attrs.namespace.as_str()),
+                output,
+            );
+
+            // Apply double-buffered state before the initial commit.
+            layer_surface.set_anchor(sctk_anchor);
+            layer_surface.set_exclusive_zone(layer_attrs.exclusive_zone);
+            let (mt, mr, mb, ml) = layer_attrs.margin;
+            layer_surface.set_margin(mt, mr, mb, ml);
+            layer_surface.set_keyboard_interactivity(sctk_ki);
+
+            // Per zwlr_layer_surface_v1.set_size: a dimension may be 0 only
+            // if it's anchored to both opposite edges on that axis.
+            // Width is "free" iff LEFT|RIGHT both set; height iff TOP|BOTTOM both set.
+            let horiz_free = sctk_anchor
+                .contains(sctk::shell::wlr_layer::Anchor::LEFT | sctk::shell::wlr_layer::Anchor::RIGHT);
+            let vert_free = sctk_anchor
+                .contains(sctk::shell::wlr_layer::Anchor::TOP | sctk::shell::wlr_layer::Anchor::BOTTOM);
+            let fallback = attributes
+                .surface_size
+                .map(|s| s.to_logical::<u32>(1.0))
+                .unwrap_or(LogicalSize::new(600, 400));
+            let init_w = if horiz_free { 0 } else { fallback.width.max(1) };
+            let init_h = if vert_free { 0 } else { fallback.height.max(1) };
+            layer_surface.set_size(init_w, init_h);
+            layer_surface.commit();
+
+            state::Shell::Layer(layer_surface)
         } else {
-            WindowDecorations::RequestClient
+            // Standard xdg toplevel path.
+            // We prefer server side decorations, however to not have decorations we ask for client
+            // side decorations instead.
+            let default_decorations = if attributes.decorations {
+                WindowDecorations::RequestServer
+            } else {
+                WindowDecorations::RequestClient
+            };
+
+            let xdg_window =
+                state.xdg_shell.create_window(surface.clone(), default_decorations, &queue_handle);
+
+            // Set the app_id.
+            if let Some(name) = app_name.map(|name| name.general) {
+                xdg_window.set_app_id(name);
+            }
+
+            // Set startup mode.
+            match attributes.fullscreen {
+                Some(Fullscreen::Exclusive(..)) => {
+                    warn!("`Fullscreen::Exclusive` is ignored on Wayland");
+                },
+                Some(Fullscreen::Borderless(monitor)) => {
+                    let out = monitor.as_ref().and_then(|monitor| {
+                        monitor.cast_ref::<output::MonitorHandle>().map(|handle| &handle.proxy)
+                    });
+
+                    xdg_window.set_fullscreen(out)
+                },
+                _ if attributes.maximized => xdg_window.set_maximized(),
+                _ => (),
+            };
+
+            // Activate the window when the token is passed.
+            if let (Some(xdg_activation), Some(token)) =
+                (xdg_activation.as_ref(), activation_token)
+            {
+                xdg_activation.activate(token.into_raw(), &surface);
+            }
+
+            // XXX Do initial commit.
+            xdg_window.commit();
+
+            state::Shell::Xdg(xdg_window)
         };
 
-        let window =
-            state.xdg_shell.create_window(surface.clone(), default_decorations, &queue_handle);
+        // Clone the shell for `Window`; the original moves into `WindowState`.
+        let shell_for_self = match &shell {
+            state::Shell::Xdg(w) => state::Shell::Xdg(w.clone()),
+            state::Shell::Layer(l) => state::Shell::Layer(l.clone()),
+        };
 
         let mut window_state = WindowState::new(
             event_loop_window_target.handle.clone(),
             &event_loop_window_target.queue_handle,
             &state,
             size,
-            window.clone(),
+            shell,
             attributes.preferred_theme,
         );
 
@@ -125,23 +227,11 @@ impl Window {
         // Set the decorations hint.
         window_state.set_decorate(attributes.decorations);
 
-        let (app_name, activation_token) =
-            match attributes.platform.take().and_then(|p| p.cast::<WindowAttributesWayland>().ok())
-            {
-                Some(attrs) => (attrs.name, attrs.activation_token),
-                None => (None, None),
-            };
-
-        // Set the app_id.
-        if let Some(name) = app_name.map(|name| name.general) {
-            window.set_app_id(name);
-        }
-
-        // Set the window title.
+        // Set the window title (no-op for layer surfaces).
         window_state.set_title(attributes.title);
 
         // Set the min and max sizes. We must set the hints upon creating a window, so
-        // we use the default `1.` scaling...
+        // we use the default `1.` scaling... (no-op for layer surfaces)
         let min_size = attributes.min_surface_size.map(|size| size.to_logical(1.));
         let max_size = attributes.max_surface_size.map(|size| size.to_logical(1.));
         window_state.set_min_surface_size(min_size);
@@ -150,34 +240,10 @@ impl Window {
         // Non-resizable implies that the min and max sizes are set to the same value.
         window_state.set_resizable(attributes.resizable);
 
-        // Set startup mode.
-        match attributes.fullscreen {
-            Some(Fullscreen::Exclusive(..)) => {
-                warn!("`Fullscreen::Exclusive` is ignored on Wayland");
-            },
-            Some(Fullscreen::Borderless(monitor)) => {
-                let output = monitor.as_ref().and_then(|monitor| {
-                    monitor.cast_ref::<output::MonitorHandle>().map(|handle| &handle.proxy)
-                });
-
-                window.set_fullscreen(output)
-            },
-            _ if attributes.maximized => window.set_maximized(),
-            _ => (),
-        };
-
         match attributes.cursor {
             Cursor::Icon(icon) => window_state.set_cursor(icon),
             Cursor::Custom(cursor) => window_state.set_custom_cursor(cursor),
         }
-
-        // Activate the window when the token is passed.
-        if let (Some(xdg_activation), Some(token)) = (xdg_activation.as_ref(), activation_token) {
-            xdg_activation.activate(token.into_raw(), &surface);
-        }
-
-        // XXX Do initial commit.
-        window.commit();
 
         // Add the window and window requests into the state.
         let window_state = Arc::new(Mutex::new(window_state));
@@ -210,7 +276,7 @@ impl Window {
         event_loop_awakener.ping();
 
         Ok(Self {
-            window,
+            window: shell_for_self,
             display,
             monitors,
             window_id,
@@ -226,7 +292,10 @@ impl Window {
     }
 
     pub(crate) fn xdg_toplevel(&self) -> Option<NonNull<c_void>> {
-        NonNull::new(self.window.xdg_toplevel().id().as_ptr().cast())
+        match &self.window {
+            state::Shell::Xdg(w) => NonNull::new(w.xdg_toplevel().id().as_ptr().cast()),
+            state::Shell::Layer(_) => None,
+        }
     }
 }
 
@@ -251,6 +320,11 @@ impl Window {
     pub fn surface(&self) -> &WlSurface {
         self.window.wl_surface()
     }
+
+    /// Returns the `wl_surface` for this window regardless of shell role.
+    fn wl_surface(&self) -> &WlSurface {
+        self.window.wl_surface()
+    }
 }
 
 impl Drop for Window {
@@ -263,7 +337,7 @@ impl Drop for Window {
 impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         let raw = rwh_06::WaylandWindowHandle::new({
-            let ptr = self.window.wl_surface().id().as_ptr();
+            let ptr = self.wl_surface().id().as_ptr();
             std::ptr::NonNull::new(ptr as *mut _).expect("wl_surface will never be null")
         });
 
@@ -422,7 +496,10 @@ impl CoreWindow for Window {
             return;
         }
 
-        self.window.set_minimized();
+        // Minimize is an xdg_toplevel feature; layer surfaces are always visible.
+        if let state::Shell::Xdg(w) = &self.window {
+            w.set_minimized();
+        }
     }
 
     fn is_minimized(&self) -> Option<bool> {
@@ -431,14 +508,21 @@ impl CoreWindow for Window {
     }
 
     fn set_maximized(&self, maximized: bool) {
-        if maximized {
-            self.window.set_maximized()
-        } else {
-            self.window.unset_maximized()
+        // Maximize is an xdg_toplevel feature; layer surfaces fill the output via anchoring.
+        if let state::Shell::Xdg(w) = &self.window {
+            if maximized {
+                w.set_maximized()
+            } else {
+                w.unset_maximized()
+            }
         }
     }
 
     fn is_maximized(&self) -> bool {
+        // Layer surfaces don't have xdg configure state.
+        if matches!(self.window, state::Shell::Layer(_)) {
+            return false;
+        }
         self.window_state
             .lock()
             .unwrap()
@@ -449,6 +533,11 @@ impl CoreWindow for Window {
     }
 
     fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
+        // Fullscreen is an xdg_toplevel feature; layer surfaces use anchor+size instead.
+        let w = match &self.window {
+            state::Shell::Xdg(w) => w,
+            state::Shell::Layer(_) => return,
+        };
         match fullscreen {
             Some(Fullscreen::Exclusive(..)) => {
                 warn!("`Fullscreen::Exclusive` is ignored on Wayland");
@@ -458,13 +547,17 @@ impl CoreWindow for Window {
                     monitor.cast_ref::<output::MonitorHandle>().map(|handle| &handle.proxy)
                 });
 
-                self.window.set_fullscreen(output)
+                w.set_fullscreen(output)
             },
-            None => self.window.unset_fullscreen(),
+            None => w.unset_fullscreen(),
         }
     }
 
     fn fullscreen(&self) -> Option<Fullscreen> {
+        // Layer surfaces don't have xdg configure state.
+        if matches!(self.window, state::Shell::Layer(_)) {
+            return None;
+        }
         let is_fullscreen = self
             .window_state
             .lock()
@@ -611,7 +704,7 @@ impl CoreWindow for Window {
     }
 
     fn set_cursor_hittest(&self, hittest: bool) -> Result<(), RequestError> {
-        let surface = self.window.wl_surface();
+        let surface = self.wl_surface();
 
         if hittest {
             surface.set_input_region(None);
@@ -625,7 +718,7 @@ impl CoreWindow for Window {
     }
 
     fn current_monitor(&self) -> Option<CoreMonitorHandle> {
-        let data = self.window.wl_surface().data::<SurfaceData>()?;
+        let data = self.wl_surface().data::<SurfaceData>()?;
         data.outputs()
             .next()
             .map(MonitorHandle::new)
@@ -656,6 +749,32 @@ impl CoreWindow for Window {
     /// Get the raw-window-handle v0.6 window handle.
     fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle {
         self
+    }
+}
+
+/// Convert public `Layer` enum to the sctk wlr_layer equivalent.
+fn convert_layer(layer: WinitLayer) -> SctkLayer {
+    match layer {
+        WinitLayer::Background => SctkLayer::Background,
+        WinitLayer::Bottom => SctkLayer::Bottom,
+        WinitLayer::Top => SctkLayer::Top,
+        WinitLayer::Overlay => SctkLayer::Overlay,
+    }
+}
+
+/// Convert public `Anchor` bitflags to the sctk wlr_layer equivalent.
+/// The two bitflag sets use identical bit assignments (TOP=1, BOTTOM=2,
+/// LEFT=4, RIGHT=8), so a direct bit cast via `from_bits_truncate` is safe.
+fn convert_anchor(anchor: WinitAnchor) -> SctkAnchor {
+    SctkAnchor::from_bits_truncate(anchor.bits())
+}
+
+/// Convert public `KeyboardInteractivity` to the sctk wlr_layer equivalent.
+fn convert_keyboard_interactivity(ki: WinitKi) -> SctkKi {
+    match ki {
+        WinitKi::None => SctkKi::None,
+        WinitKi::OnDemand => SctkKi::OnDemand,
+        WinitKi::Exclusive => SctkKi::Exclusive,
     }
 }
 

--- a/winit-wayland/src/window/state.rs
+++ b/winit-wayland/src/window/state.rs
@@ -472,10 +472,9 @@ impl WindowState {
             Shell::Xdg(w) => w.xdg_toplevel(),
             // Layer surfaces are compositor-positioned; interactive move is not applicable.
             Shell::Layer(_) => {
-                return Err(NotSupportedError::new(
-                    "drag-move is not supported for layer surfaces",
+                return Err(
+                    NotSupportedError::new("drag-move is not supported for layer surfaces").into()
                 )
-                .into())
             },
         };
         // TODO(kchibisov) handle touch serials.

--- a/winit-wayland/src/window/state.rs
+++ b/winit-wayland/src/window/state.rs
@@ -21,6 +21,7 @@ use sctk::reexports::protocols::wp::text_input::zv3::client::zwp_text_input_v3::
 use sctk::reexports::protocols::wp::viewporter::client::wp_viewport::WpViewport;
 use sctk::reexports::protocols::xdg::shell::client::xdg_toplevel::ResizeEdge as XdgResizeEdge;
 use sctk::seat::pointer::{PointerDataExt, ThemedPointer};
+use sctk::shell::wlr_layer::LayerSurface;
 use sctk::shell::xdg::window::{DecorationMode, Window, WindowConfigure};
 use sctk::shell::xdg::XdgSurface;
 use sctk::shell::WaylandSurface;
@@ -160,8 +161,12 @@ pub struct WindowState {
     /// The value is the serial of the event triggered moved.
     has_pending_move: Option<u32>,
 
-    /// The underlying SCTK window.
-    pub window: Window,
+    /// The underlying SCTK shell role — either an xdg toplevel or a layer surface.
+    pub window: Shell,
+
+    /// Whether a layer surface has received its first configure. Always `false`
+    /// for xdg toplevels; those use `last_configure.is_some()` instead.
+    layer_configured: bool,
 
     // NOTE: The spec says that destroying parent(`window` in our case), will unmap the
     // subsurfaces. Thus to achieve atomic unmap of the client, drop the decorations
@@ -171,6 +176,32 @@ pub struct WindowState {
     frame: Option<WinitFrame>,
 }
 
+/// Which Wayland shell role backs this window.
+#[derive(Debug)]
+pub enum Shell {
+    Xdg(Window),
+    Layer(LayerSurface),
+}
+
+impl Shell {
+    pub fn wl_surface(&self) -> &WlSurface {
+        match self {
+            Shell::Xdg(w) => w.wl_surface(),
+            Shell::Layer(l) => l.wl_surface(),
+        }
+    }
+
+    /// Set buffer scale. Layer surfaces inherit output scale from the
+    /// compositor, but the underlying `WaylandSurface` impl still accepts
+    /// the call safely.
+    pub fn set_buffer_scale(&self, scale: u32) -> Result<(), sctk::shell::Unsupported> {
+        match self {
+            Shell::Xdg(w) => w.set_buffer_scale(scale),
+            Shell::Layer(l) => l.set_buffer_scale(scale),
+        }
+    }
+}
+
 impl WindowState {
     /// Create new window state.
     pub fn new(
@@ -178,19 +209,20 @@ impl WindowState {
         queue_handle: &QueueHandle<WinitState>,
         winit_state: &WinitState,
         initial_size: Size,
-        window: Window,
+        window: Shell,
         theme: Option<Theme>,
     ) -> Self {
         let compositor = winit_state.compositor_state.clone();
         let pointer_constraints = winit_state.pointer_constraints.clone();
+        let wl_surface = window.wl_surface();
         let viewport = winit_state
             .viewporter_state
             .as_ref()
-            .map(|state| state.get_viewport(window.wl_surface(), queue_handle));
+            .map(|state| state.get_viewport(wl_surface, queue_handle));
         let fractional_scale = winit_state
             .fractional_scaling_manager
             .as_ref()
-            .map(|fsm| fsm.fractional_scaling(window.wl_surface(), queue_handle));
+            .map(|fsm| fsm.fractional_scaling(wl_surface, queue_handle));
 
         let xdg_toplevel_icon_manager = winit_state
             .xdg_toplevel_icon_manager
@@ -234,6 +266,7 @@ impl WindowState {
             transparent: false,
             viewport,
             window,
+            layer_configured: false,
         }
     }
 
@@ -265,7 +298,7 @@ impl WindowState {
 
     /// Request a frame callback if we don't have one for this window in flight.
     pub fn request_frame_callback(&mut self) {
-        let surface = self.window.wl_surface();
+        let surface = self.window.wl_surface().clone();
         match self.frame_callback_state {
             FrameCallbackState::None | FrameCallbackState::Received => {
                 self.frame_callback_state = FrameCallbackState::Requested;
@@ -289,36 +322,40 @@ impl WindowState {
             self.stateless_size = self.size;
         }
 
-        if let Some(subcompositor) = subcompositor.as_ref().filter(|_| {
-            configure.decoration_mode == DecorationMode::Client
-                && self.frame.is_none()
-                && !self.csd_fails
-        }) {
-            match WinitFrame::new(
-                &self.window,
-                shm,
-                #[cfg(feature = "sctk-adwaita")]
-                self.compositor.clone(),
-                subcompositor.clone(),
-                self.queue_handle.clone(),
-                #[cfg(feature = "sctk-adwaita")]
-                create_sctk_adwaita_config(self.theme),
-            ) {
-                Ok(mut frame) => {
-                    frame.set_title(&self.title);
-                    frame.set_scaling_factor(self.scale_factor);
-                    // Hide the frame if we were asked to not decorate.
-                    frame.set_hidden(!self.decorate);
-                    self.frame = Some(frame);
-                },
-                Err(err) => {
-                    warn!("Failed to create client side decorations frame: {err}");
-                    self.csd_fails = true;
-                },
+        // CSD frames are only for xdg toplevels; layer surfaces have no
+        // decoration protocol equivalent.
+        if let Shell::Xdg(ref xdg_window) = self.window {
+            if let Some(subcompositor) = subcompositor.as_ref().filter(|_| {
+                configure.decoration_mode == DecorationMode::Client
+                    && self.frame.is_none()
+                    && !self.csd_fails
+            }) {
+                match WinitFrame::new(
+                    xdg_window,
+                    shm,
+                    #[cfg(feature = "sctk-adwaita")]
+                    self.compositor.clone(),
+                    subcompositor.clone(),
+                    self.queue_handle.clone(),
+                    #[cfg(feature = "sctk-adwaita")]
+                    create_sctk_adwaita_config(self.theme),
+                ) {
+                    Ok(mut frame) => {
+                        frame.set_title(&self.title);
+                        frame.set_scaling_factor(self.scale_factor);
+                        // Hide the frame if we were asked to not decorate.
+                        frame.set_hidden(!self.decorate);
+                        self.frame = Some(frame);
+                    },
+                    Err(err) => {
+                        warn!("Failed to create client side decorations frame: {err}");
+                        self.csd_fails = true;
+                    },
+                }
+            } else if configure.decoration_mode == DecorationMode::Server {
+                // Drop the frame for server side decorations to save resources.
+                self.frame = None;
             }
-        } else if configure.decoration_mode == DecorationMode::Server {
-            // Drop the frame for server side decorations to save resources.
-            self.frame = None;
         }
 
         let stateless = Self::is_stateless(&configure);
@@ -408,7 +445,16 @@ impl WindowState {
 
     /// Start interacting drag resize.
     pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), RequestError> {
-        let xdg_toplevel = self.window.xdg_toplevel();
+        let xdg_toplevel = match &self.window {
+            Shell::Xdg(w) => w.xdg_toplevel(),
+            // Layer surfaces are positioned by the compositor; interactive resize is not applicable.
+            Shell::Layer(_) => {
+                return Err(NotSupportedError::new(
+                    "drag-resize is not supported for layer surfaces",
+                )
+                .into())
+            },
+        };
 
         // TODO(kchibisov) handle touch serials.
         self.apply_on_pointer(|_, data| {
@@ -422,7 +468,16 @@ impl WindowState {
 
     /// Start the window drag.
     pub fn drag_window(&self) -> Result<(), RequestError> {
-        let xdg_toplevel = self.window.xdg_toplevel();
+        let xdg_toplevel = match &self.window {
+            Shell::Xdg(w) => w.xdg_toplevel(),
+            // Layer surfaces are compositor-positioned; interactive move is not applicable.
+            Shell::Layer(_) => {
+                return Err(NotSupportedError::new(
+                    "drag-move is not supported for layer surfaces",
+                )
+                .into())
+            },
+        };
         // TODO(kchibisov) handle touch serials.
         self.apply_on_pointer(|_, data| {
             let serial = data.latest_button_serial();
@@ -445,10 +500,16 @@ impl WindowState {
         window_id: WindowId,
         updates: &mut Vec<WindowCompositorUpdate>,
     ) -> Option<bool> {
+        // CSD frames only appear on xdg toplevels; layer surfaces never have a
+        // WinitFrame so frame.as_mut() above already returns None for them.
+        let xdg_window = match &self.window {
+            Shell::Xdg(w) => w,
+            Shell::Layer(_) => return None,
+        };
         match self.frame.as_mut()?.on_click(timestamp, click, pressed)? {
-            FrameAction::Minimize => self.window.set_minimized(),
-            FrameAction::Maximize => self.window.set_maximized(),
-            FrameAction::UnMaximize => self.window.unset_maximized(),
+            FrameAction::Minimize => xdg_window.set_minimized(),
+            FrameAction::Maximize => xdg_window.set_maximized(),
+            FrameAction::UnMaximize => xdg_window.unset_maximized(),
             FrameAction::Close => WinitState::queue_close(updates, window_id),
             FrameAction::Move => self.has_pending_move = Some(serial),
             FrameAction::Resize(edge) => {
@@ -464,9 +525,9 @@ impl WindowState {
                     ResizeEdge::BottomRight => XdgResizeEdge::BottomRight,
                     _ => return None,
                 };
-                self.window.resize(seat, serial, edge);
+                xdg_window.resize(seat, serial, edge);
             },
-            FrameAction::ShowMenu(x, y) => self.window.show_window_menu(seat, serial, (x, y)),
+            FrameAction::ShowMenu(x, y) => xdg_window.show_window_menu(seat, serial, (x, y)),
             _ => (),
         };
 
@@ -496,7 +557,10 @@ impl WindowState {
             // If we have a cursor change, that means that cursor is over the decorations,
             // so try to apply move.
             if let Some(serial) = cursor.is_some().then_some(serial).flatten() {
-                self.window.move_(seat, serial);
+                // Only xdg toplevels support interactive move via the compositor.
+                if let Shell::Xdg(w) = &self.window {
+                    w.move_(seat, serial);
+                }
                 None
             } else {
                 cursor
@@ -563,7 +627,31 @@ impl WindowState {
     /// Whether the window received initial configure event from the compositor.
     #[inline]
     pub fn is_configured(&self) -> bool {
-        self.last_configure.is_some()
+        match &self.window {
+            Shell::Xdg(_) => self.last_configure.is_some(),
+            Shell::Layer(_) => self.layer_configured,
+        }
+    }
+
+    /// Mark a layer surface as having received its initial configure.
+    pub fn mark_layer_configured(&mut self) {
+        self.layer_configured = true;
+    }
+
+    /// Apply a new size from a layer-surface configure WITHOUT triggering
+    /// the xdg-specific resize side-effects (CSD frame resize,
+    /// xdg_surface.set_window_geometry, etc.). Only mutates the stored
+    /// size and the viewport destination when both axes are non-zero —
+    /// wp_viewport.set_destination rejects zero on either axis with a
+    /// protocol error, which we'd hit because layer surfaces commonly
+    /// receive configures with one axis = 0 (= "you decide").
+    pub(crate) fn apply_layer_size(&mut self, inner_size: dpi::LogicalSize<u32>) {
+        self.size = inner_size;
+        if let Some(viewport) = self.viewport.as_ref() {
+            if inner_size.width > 0 && inner_size.height > 0 {
+                viewport.set_destination(inner_size.width as _, inner_size.height as _);
+            }
+        }
     }
 
     #[inline]
@@ -638,7 +726,7 @@ impl WindowState {
 
     /// Reissue the transparency hint to the compositor.
     pub fn reload_transparency_hint(&self) {
-        let surface = self.window.wl_surface();
+        let surface = self.window.wl_surface().clone();
 
         if self.transparent {
             surface.set_opaque_region(None);
@@ -686,13 +774,16 @@ impl WindowState {
         // Reload the hint.
         self.reload_transparency_hint();
 
-        // Set the window geometry.
-        self.window.xdg_surface().set_window_geometry(
-            x,
-            y,
-            outer_size.width as i32,
-            outer_size.height as i32,
-        );
+        // Set the window geometry. Layer surfaces don't have an xdg_surface;
+        // the compositor uses the anchor/size state set during creation.
+        if let Shell::Xdg(w) = &self.window {
+            w.xdg_surface().set_window_geometry(
+                x,
+                y,
+                outer_size.width as i32,
+                outer_size.height as i32,
+            );
+        }
 
         // Update the target viewport, this is used if and only if fractional scaling is in use.
         if let Some(viewport) = self.viewport.as_ref() {
@@ -795,7 +886,10 @@ impl WindowState {
             .unwrap_or(size);
 
         self.min_surface_size = size;
-        self.window.set_min_size(Some(size.into()));
+        // min/max size hints are xdg_toplevel-only; layer surfaces have no equivalent.
+        if let Shell::Xdg(w) = &self.window {
+            w.set_min_size(Some(size.into()));
+        }
     }
 
     /// Set maximum inner window size.
@@ -808,7 +902,10 @@ impl WindowState {
         });
 
         self.max_surface_size = size;
-        self.window.set_max_size(size.map(Into::into));
+        // min/max size hints are xdg_toplevel-only; layer surfaces have no equivalent.
+        if let Shell::Xdg(w) = &self.window {
+            w.set_max_size(size.map(Into::into));
+        }
     }
 
     /// Set the CSD theme.
@@ -878,16 +975,16 @@ impl WindowState {
         }
 
         let mut set_mode = false;
-        let surface = self.window.wl_surface();
+        let surface = self.window.wl_surface().clone();
         match mode {
             CursorGrabMode::Locked => self.apply_on_pointer(|pointer, data| {
                 let pointer = pointer.pointer();
-                data.lock_pointer(pointer_constraints, surface, pointer, &self.queue_handle);
+                data.lock_pointer(pointer_constraints, &surface, pointer, &self.queue_handle);
                 set_mode = true;
             }),
             CursorGrabMode::Confined => self.apply_on_pointer(|pointer, data| {
                 let pointer = pointer.pointer();
-                data.confine_pointer(pointer_constraints, surface, pointer, &self.queue_handle);
+                data.confine_pointer(pointer_constraints, &surface, pointer, &self.queue_handle);
                 set_mode = true;
             }),
             CursorGrabMode::None => {
@@ -905,12 +1002,15 @@ impl WindowState {
     }
 
     pub fn show_window_menu(&self, position: LogicalPosition<u32>) {
-        // TODO(kchibisov) handle touch serials.
-        self.apply_on_pointer(|_, data| {
-            let serial = data.latest_button_serial();
-            let seat = data.seat();
-            self.window.show_window_menu(seat, serial, position.into());
-        });
+        // Only xdg toplevels support the window menu (compositor-drawn context menu).
+        if let Shell::Xdg(w) = &self.window {
+            // TODO(kchibisov) handle touch serials.
+            self.apply_on_pointer(|_, data| {
+                let serial = data.latest_button_serial();
+                let seat = data.seat();
+                w.show_window_menu(seat, serial, position.into());
+            });
+        }
     }
 
     /// Set the position of the cursor.
@@ -961,13 +1061,17 @@ impl WindowState {
 
         self.decorate = decorate;
 
-        match self.last_configure.as_ref().map(|configure| configure.decoration_mode) {
-            Some(DecorationMode::Server) if !self.decorate => {
-                // To disable decorations we should request client and hide the frame.
-                self.window.request_decoration_mode(Some(DecorationMode::Client))
-            },
-            _ if self.decorate => self.window.request_decoration_mode(Some(DecorationMode::Server)),
-            _ => (),
+        // Decoration mode negotiation is an xdg_toplevel protocol feature; layer
+        // surfaces have no decoration protocol equivalent.
+        if let Shell::Xdg(w) = &self.window {
+            match self.last_configure.as_ref().map(|configure| configure.decoration_mode) {
+                Some(DecorationMode::Server) if !self.decorate => {
+                    // To disable decorations we should request client and hide the frame.
+                    w.request_decoration_mode(Some(DecorationMode::Client))
+                },
+                _ if self.decorate => w.request_decoration_mode(Some(DecorationMode::Server)),
+                _ => (),
+            }
         }
 
         if let Some(frame) = self.frame.as_mut() {
@@ -1051,7 +1155,7 @@ impl WindowState {
 
         // NOTE: When fractional scaling is not used update the buffer scale.
         if self.fractional_scale.is_none() {
-            let _ = self.window.set_buffer_scale(self.scale_factor as _);
+            let _ = self.window.set_buffer_scale(self.scale_factor as u32);
         }
 
         if let Some(frame) = self.frame.as_mut() {
@@ -1064,14 +1168,16 @@ impl WindowState {
     pub fn set_blur(&mut self, blurred: bool) {
         if blurred && self.blur.is_none() {
             if let Some(blur_manager) = self.blur_manager.as_ref() {
-                let blur = blur_manager.blur(self.window.wl_surface(), &self.queue_handle);
+                let surface = self.window.wl_surface().clone();
+                let blur = blur_manager.blur(&surface, &self.queue_handle);
                 blur.commit();
                 self.blur = Some(blur);
             } else {
                 info!("Blur manager unavailable, unable to change blur")
             }
         } else if !blurred && self.blur.is_some() {
-            self.blur_manager.as_ref().unwrap().unset(self.window.wl_surface());
+            let surface = self.window.wl_surface().clone();
+            self.blur_manager.as_ref().unwrap().unset(&surface);
             self.blur.take().unwrap().release();
         }
     }
@@ -1095,7 +1201,10 @@ impl WindowState {
             frame.set_title(&title);
         }
 
-        self.window.set_title(&title);
+        // Title is an xdg_toplevel property; layer surfaces have no title concept.
+        if let Shell::Xdg(w) = &self.window {
+            w.set_title(&title);
+        }
         self.title = title;
     }
 
@@ -1130,7 +1239,12 @@ impl WindowState {
             None => (None, None),
         };
 
-        xdg_toplevel_icon_manager.set_icon(self.window.xdg_toplevel(), xdg_toplevel_icon.as_ref());
+        // Icons are an xdg_toplevel feature; silently skip for layer surfaces.
+        let xdg_toplevel = match &self.window {
+            Shell::Xdg(w) => w.xdg_toplevel(),
+            Shell::Layer(_) => return,
+        };
+        xdg_toplevel_icon_manager.set_icon(xdg_toplevel, xdg_toplevel_icon.as_ref());
         self.toplevel_icon = toplevel_icon;
 
         if let Some(xdg_toplevel_icon) = xdg_toplevel_icon {


### PR DESCRIPTION
## Summary

Adds `zwlr_layer_shell_v1` support to `floem-winit-wayland`. A window built with the new `WindowAttributesWayland::with_layer_shell(...)` becomes a layer surface instead of an `xdg_toplevel`, enabling rofi-style top-layer overlays, lockscreens, panels, and notifications — the standard wlr-layer-shell use cases.

Six commits, kept distinct so each is reviewable on its own:

1. **feat(wayland): add LayerShellAttributes types + WindowAttributesWayland::with_layer_shell** — pure public surface. New `Layer`, `Anchor` (bitflags), `KeyboardInteractivity`, `LayerShellAttributes` types in a new `layer_shell` module. No backend yet.
2. **feat(wayland): bind LayerShell global + delegate_layer stub** — bind `wlr_layer_shell::LayerShell` alongside `XdgShell` in `WinitState`. `Option<LayerShell>` so compositors that don't advertise the protocol (notably GNOME Mutter) return `None` and the caller can fall back. `delegate_layer!` registered, handler stubbed.
3. **feat(wayland): Window::new layer-surface branch + handler routing** — `WindowState.window` becomes a `Shell::Xdg(...) | Shell::Layer(...)` enum. Xdg-only operations (title, app_id, min/max size, decorations, minimize, maximize, fullscreen, show_window_menu, etc.) early-return on `Shell::Layer`. `LayerShellHandler::configure` routes into per-window state.
4. **fix(wayland): layer configure must mutate WindowState.size + per-axis zero** — `zwlr_layer_surface_v1.configure` `(W, 0)` means "client decides for the height axis", not "both axes unchanged". Treated each axis independently. Also: the original handler was a no-op on `WindowState.size`; it now mutates and sets `resized = true` so the event loop fires `SurfaceResized`.
5. **fix(wayland): respect anchor topology in set_size + don't reuse xdg resize** — a layer-surface dimension may be zero ONLY when anchored to both opposite edges on that axis. With the typical rofi anchor pattern `TOP | LEFT | RIGHT`, the height axis only has `TOP` — zero height is a protocol error and the compositor disconnects. Per-axis derivation from the anchor mask, plus skip the xdg-style `resize_request` path on layer surfaces.
6. **fix(wayland): default KeyboardInteractivity to OnDemand + expose wl_layer_surface** — `Exclusive` is the wrong default for launchers: it monopolises the keyboard at the compositor level, so binding (Hyprland's window-close, sway's `mod+q`) stops firing and the only escape is SIGKILL from a TTY. `OnDemand` is what rofi/wofi/fuzzel ship with; lockers can opt back into `Exclusive`. Bonus: `WindowExtWayland::wl_layer_surface()` accessor mirroring the existing `xdg_toplevel()`.

## Why

Bridging this gap is what unblocks floem-based launcher / picker / overlay apps on Wayland — currently the only path is `xdg_toplevel`, which produces a draggable, decorated window that the compositor places in the regular toplevel stack. We've been running this support for a few months on a `floem-winit 0.29.5`-rooted fork against pikr (a rofi replacement); this PR ports it to current master.

## Provenance

Originally developed on `mxaddict/winit:layer-shell` (rooted on the `floem-winit 0.29.5` crates.io snapshot). Re-applied as 6 logically-isolated commits on top of current master. ~520 LOC added across `winit-wayland/{lib.rs, layer_shell.rs (new), state.rs, window/{mod.rs, state.rs}}`.

## Test plan

- [x] `cargo check -p floem-winit-wayland` — clean.
- [x] `cargo clippy -p floem-winit-wayland --all-targets -- -D warnings` — clean.
- [x] `cargo fmt` on the touched winit-wayland files — clean.
- [x] Manual smoke test with [pikr](https://github.com/kryptic-sh/pikr) (rofi replacement, layer-shell on Hyprland + sway) against the legacy fork, identical behaviour expected from this port.

## Out of scope

- `winit-x11` and `winit-orbital` have pre-existing `cargo check` errors on master that this branch does not touch. `cargo check --workspace` is broken regardless of these commits; per-crate check on `floem-winit-wayland` is the relevant signal.
- No tests — layer-shell needs a real Wayland compositor with the wlr-layer-shell extension; integration testing happens downstream in pikr / etc.